### PR TITLE
Relocate vertical_box_container_break.gd

### DIFF
--- a/classes/custom_dialog.gd
+++ b/classes/custom_dialog.gd
@@ -56,7 +56,7 @@ func _init(dialog_text := "", confirm_text := "dialog_yes", cancel_text := "dial
 	buttons_hb = BoxContainer.new()
 	buttons_hb.custom_minimum_size.x = 620
 	resized.connect(_buttons_resized)
-	buttons_hb.set_script(load("res://addons/blazium_shared_menus/game_shared_ui/vertical_box_container_break.gd"))
+	buttons_hb.set_script(load("res://addons/blazium_theme_editor/classes/vertical_box_container_break.gd"))
 	buttons_hb.alignment = BoxContainer.ALIGNMENT_CENTER
 	buttons_hb.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	buttons_hb.add_theme_constant_override("separation", 24)

--- a/classes/vertical_box_container_break.gd
+++ b/classes/vertical_box_container_break.gd
@@ -1,0 +1,9 @@
+extends BoxContainer
+
+func _ready():
+	_size_changed()
+	get_tree().root.size_changed.connect(_size_changed)
+
+
+func _size_changed():
+	vertical = GlobalLobbyClient.ui_breakpoint()

--- a/classes/vertical_box_container_break.gd.uid
+++ b/classes/vertical_box_container_break.gd.uid
@@ -1,0 +1,1 @@
+uid://chix1djhx5hj3


### PR DESCRIPTION
This should really just be eliminated, but cleanup has already been delaying other refactors